### PR TITLE
Able to make the active track bar draggable or not

### DIFF
--- a/lib/flutter_xlider.dart
+++ b/lib/flutter_xlider.dart
@@ -1708,12 +1708,16 @@ class _FlutterSliderState extends State<FlutterSlider>
 
               setState(() {});
             },
-            child: Draggable(
+            child: Visibility(
+              visible: widget.trackBar.activeTrackBarDraggable,
+              child: Draggable(
                 axis: widget.axis,
                 feedback: Container(),
                 child: Container(
                   color: Colors.redAccent,
-                )),
+                ),
+              ),
+            ),
           ),
         )));
 
@@ -2215,6 +2219,7 @@ class FlutterSliderTooltipBox {
 class FlutterSliderTrackBar {
   final BoxDecoration inactiveTrackBar;
   final BoxDecoration activeTrackBar;
+  final bool activeTrackBarDraggable;
   final Color activeDisabledTrackBarColor;
   final Color inactiveDisabledTrackBarColor;
   final double activeTrackBarHeight;
@@ -2224,6 +2229,7 @@ class FlutterSliderTrackBar {
   const FlutterSliderTrackBar({
     this.inactiveTrackBar,
     this.activeTrackBar,
+    this.activeTrackBarDraggable = true,
     this.activeDisabledTrackBarColor = const Color(0xffb5b5b5),
     this.inactiveDisabledTrackBarColor = const Color(0xffe5e5e5),
     this.activeTrackBarHeight = 3.5,


### PR DESCRIPTION
Hi,

Please help to check this PR.

Thanks 😄 

---
**Current issue**: with **selectByTap = false**, the active track bar is draggable even when it's not a range slider.

![Screen Recording 2020-03-09 at 17 57 02](https://user-images.githubusercontent.com/8677412/76207202-e8fb7500-622f-11ea-919b-dcd82347efac.gif)

Example code:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/8677412/76207233-f6b0fa80-622f-11ea-82e7-31171791e36d.png">

**In both case, the callbacks are not fired**.

**Resolution**: Not sure if it's a feature or a bug. In this PR, I added a new attribute to indicate if the active track bar is draggable or not.


