### PR TITLE
Fix initial rendering of inactive trackbar

### DIFF
--- a/lib/flutter_xlider.dart
+++ b/lib/flutter_xlider.dart
@@ -260,6 +260,8 @@ class _FlutterSliderState extends State<FlutterSlider>
             builder: (BuildContext context, BoxConstraints constraints) {
           _constraintMaxWidth = constraints.maxWidth;
           _constraintMaxHeight = constraints.maxHeight;
+          _arrangeHandlersPosition();
+
 
           _containerWidthWithoutPadding = _constraintMaxWidth - _handlersWidth!;
           _containerHeightWithoutPadding =
@@ -441,8 +443,6 @@ class _FlutterSliderState extends State<FlutterSlider>
 
     WidgetsBinding.instance!.addPostFrameCallback((_) {
       _renderBoxInitialization();
-
-      _arrangeHandlersPosition();
 
       _drawHatchMark();
 


### PR DESCRIPTION
`_inactiveTrack()` calculates `top` and `left` from `_handlersPadding`.
But `_handlersPadding` is calculated in `_arrangeHandlersPosition()` after the inactive track is initially drawn.
`_arrangeHandlersPosition()` uses `_contraintMaxWidth` and `_constraintMaxHeight`. This commit calculates it early enough when the required values are ready.

This might improve / solve #105 