### PR TITLE
#118 call _renderBoxInitialization in onPointerDown on trackbar

### DIFF
--- a/lib/flutter_xlider.dart
+++ b/lib/flutter_xlider.dart
@@ -1831,6 +1831,8 @@ class _FlutterSliderState extends State<FlutterSlider>
               __dragging = false;
               _trackBarSlideOnDragStartedCalled = false;
 
+              _renderBoxInitialization();
+
               double leftHandlerLastPosition, rightHandlerLastPosition;
               if (widget.axis == Axis.horizontal) {
                 double lX = _leftHandlerXPosition! +


### PR DESCRIPTION
This fixes #118

The cause of #118 is lack of calling `_renderBoxInitialization` method on `onPointerDown` callback. So I simply will call the method when trackbar's `onPointerDown` is called.

I confirmed this will fix #118 by below code:

```dart
import 'package:another_xlider/another_xlider.dart';
import 'package:flutter/material.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        appBar: AppBar(
          title: Text('Sample'),
        ),
        body: Center(
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[
              Builder(builder: (context) {
                return TextButton(
                  onPressed: () {
                    Navigator.of(context).push(
                      MaterialPageRoute(
                        builder: (context) => SliderView(),
                      ),
                    );
                  },
                  child:
                      Text('Show Slider View', style: TextStyle(fontSize: 30)),
                );
              }),
            ],
          ),
        ),
      ),
    );
  }
}

class SliderView extends StatefulWidget {
  @override
  _SliderViewState createState() => _SliderViewState();
}

class _SliderViewState extends State<SliderView> {
  double _sliderValue = 0.0;

  @override
  void initState() {
    super.initState();

    // To reproduce the bug,
    // the duration of `delayed` should be less than transition animation's duration (maybe 300ms).
    // For example, this demo uses 1ms.
    Future.delayed(Duration(milliseconds: 1)).then((_) {
      setState(() {
        _sliderValue = 50;
      });
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(),
      body: SafeArea(
        child: Center(
          child: FlutterSlider(
            values: [_sliderValue],
            min: 0,
            max: 100,
          ),
        ),
      ),
    );
  }
}

```

Thank you ❤️ 