### PR TITLE
feature: fixed unmounted exception

### DIFF
--- a/lib/flutter_xlider.dart
+++ b/lib/flutter_xlider.dart
@@ -440,6 +440,8 @@ class _FlutterSliderState extends State<FlutterSlider>
                 curve: Curves.fastOutSlowIn));
 
     WidgetsBinding.instance!.addPostFrameCallback((_) {
+      if (!mounted) return;
+
       _renderBoxInitialization();
 
       _arrangeHandlersPosition();


### PR DESCRIPTION
======== Exception caught by scheduler library =====================================================

This widget has been unmounted, so the State no longer has a context (and should be considered defunct).