### PR TITLE
fix: clear warnings from Flutter 3.0.0

### DIFF
--- a/lib/flutter_xlider.dart
+++ b/lib/flutter_xlider.dart
@@ -439,7 +439,7 @@ class _FlutterSliderState extends State<FlutterSlider>
                 parent: _rightTooltipAnimationController,
                 curve: Curves.fastOutSlowIn));
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       _renderBoxInitialization();
 
       _arrangeHandlersPosition();


### PR DESCRIPTION
In Flutter 3.0.0, the instance of WidgetsBinding is no longer nullable, so forcing that instance to not null with `!` is no longer necessary.

Tested also on the latest Flutter hotfix 3.0.5.

More insights:
In my case throwing warning had a significant impact on running tests. With warning, I observed 30-40% more time needed to execute all tests.
