### PR TITLE
Added tooltip side to custom tooltip callback

### DIFF
--- a/lib/src/model/flutter_slider_tooltip.dart
+++ b/lib/src/model/flutter_slider_tooltip.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_xlider/flutter_xlider.dart';
 
 class FlutterSliderTooltip {
-  Widget Function(dynamic value)? custom;
+  Widget Function(dynamic value, String? side)? custom;
   String Function(String value)? format;
   TextStyle? textStyle;
   FlutterSliderTooltipBox? boxStyle;

--- a/lib/src/view/flutter_slider_widget.dart
+++ b/lib/src/view/flutter_slider_widget.dart
@@ -2000,7 +2000,7 @@ class _FlutterSliderState extends State<FlutterSlider>
           key: (side == 'left') ? leftTooltipKey : rightTooltipKey,
 //            alignment: Alignment.center,
           child: (widget.tooltip != null && widget.tooltip!.custom != null)
-              ? widget.tooltip!.custom!(value)
+              ? widget.tooltip!.custom!(value, side)
               : Container(
                   padding: EdgeInsets.all(8),
                   decoration: _tooltipData.boxStyle!.decoration,


### PR DESCRIPTION
With this change the custom tooltip callback send handler side together with the value.
This allows to customize the tooltip according to the handler side.

It would probably be more elegant to define an enumeration with left and right members and pass that type instead of String, but this way works fine with minimal code changes.

